### PR TITLE
add golangci-lint config file

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,32 @@
+---
+linters:
+  disable-all: false
+  enable:
+    - bodyclose
+    - errcheck
+    - errorlint
+    - exportloopref
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ineffassign
+    - misspell
+    - noctx
+    - nolintlint
+    - nosprintfhostport
+    - prealloc
+    - revive
+    - staticcheck
+    - tenv
+    - typecheck
+    - unconvert
+    - unused
+    - usestdlibvars
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/simplesurance/cfdns
+
+issues:
+  exclude-use-default: true


### PR DESCRIPTION
add a golangci-lint config files, that enables some more linters then the defaults ones + sets the goimports local prefix