### PR TITLE
tests: adapt tests to pass, after breaking changes made by CloudFlare

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,5 +184,5 @@ for _, cfe := range cfErr.Errors {
 
 // Output:
 // Got HTTP error 400
-// - CF error 1004: DNS Validation Error
+// - CF error 9005: Content for A record must be a valid IPv4 address.
 ```

--- a/client.go
+++ b/client.go
@@ -240,7 +240,7 @@ func handleErrorResponse(resp *http.Response, _ *log.Logger) error {
 	var cfcommon cfResponseCommon
 	err = json.Unmarshal(respBody, &cfcommon)
 	if err != nil {
-		return retry.PermanentError{Cause: fmt.Errorf("CloudFlare returned an error, unmarshalling the error body as json failed: %w; %w", err, httpErr)}
+		return retry.PermanentError{Cause: fmt.Errorf("CloudFlare returned an error, unmarshaling the error body as json failed: %w; %w", err, httpErr)}
 	}
 
 	ret := CloudFlareError{

--- a/client_test.go
+++ b/client_test.go
@@ -155,7 +155,7 @@ func TestConflict(t *testing.T) {
 		{
 			typ:           "A",
 			content:       "1.1.1.1",
-			wantErrorCode: 81057,
+			wantErrorCode: 81058,
 		},
 	}
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -140,5 +140,5 @@ func ExampleCloudFlareError() {
 
 	// Output:
 	// Got HTTP error 400
-	// - CF error 1004: DNS Validation Error
+	// - CF error 9005: Content for A record must be a valid IPv4 address.
 }


### PR DESCRIPTION
CloudFlare has broken API compatibility by changing the error status codes returned for some cases. This broke some tests on the library.

Since this library exposes the original status code, users of the library are recommended to check code that uses them against the CloudFlare documentation, to look for changes.

This is the list of changes returned from CloudFlare that affect test code on this library:

1. When an `A` (IPv4 address) record is being created, if it already exists the API used to produce error code `81057`. Now it returns code `81058`.
2. When an `A` DNS record is being created, but the content is not a valid IPv4 address, the response code used to be CF error `1004: DNS Validation Error`. Now it is `9005: Content for A record must be a valid IPv4 address.`.