### PR TITLE
fix: fix test and check compatibility with go version on go.mod

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.23", "stable"]
+        go: ["1.24", "stable"]
     name: test
     runs-on: ubuntu-latest
     steps:
@@ -31,7 +31,7 @@ jobs:
   golangci:
     strategy:
       matrix:
-        go: ["1.23", "stable"]
+        go: ["1.24", "stable"]
         lint: ["v2.5.0"]
     name: lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
`go.mod` is declaring version 1.24, but tests and checks were trying to run with go 1.23, which fails.